### PR TITLE
Tetris random piece generator was not really random

### DIFF
--- a/java/code/src/main/java/oop/swing/tetris/TetrisPanel.java
+++ b/java/code/src/main/java/oop/swing/tetris/TetrisPanel.java
@@ -5,8 +5,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+import java.util.Random;
 import java.util.random.RandomGenerator;
-import java.util.random.RandomGeneratorFactory;
 
 import javax.swing.*;
 
@@ -94,7 +94,7 @@ public class TetrisPanel extends JPanel implements KeyListener, ActionListener {
     }
 
     private void generatePiece() {
-        RandomGenerator rnd = RandomGeneratorFactory.getDefault().create();
+        RandomGenerator rnd = new Random();
         currentPiece = new Piece(board, rnd.nextInt(7), 0, new Point(BOARD_MAX_X / 2, 1));
     }
 


### PR DESCRIPTION
Fixed a bug in TetrisPanel generatePiece method that was causing the creation of only L-pieces by passing "type: 2" to the Piece constructor.